### PR TITLE
Avoid shared nodes in control flow passes

### DIFF
--- a/src/deobfuscator/helpers/misc.ts
+++ b/src/deobfuscator/helpers/misc.ts
@@ -18,7 +18,7 @@ export const copyExpression = (expression: t.Expression): t.Expression => {
  * @param value The value.
  */
 export const setProperty = (obj: any, property: string, value: any): void => {
-    (obj as Record<string, any>).property = value;
+    (obj as Record<string, any>)[property] = value;
 };
 
 /**
@@ -28,5 +28,5 @@ export const setProperty = (obj: any, property: string, value: any): void => {
  * @returns
  */
 export const getProperty = (obj: any, property: string): any => {
-    return (obj as Record<string, any>).property;
+    return (obj as Record<string, any>)[property];
 };

--- a/src/deobfuscator/transformations/controlFlow/controlFlowRecoverer.ts
+++ b/src/deobfuscator/transformations/controlFlow/controlFlowRecoverer.ts
@@ -60,7 +60,7 @@ export class ControlFlowRecoverer extends Transformation {
                     cases.map(c => [(c.test as t.StringLiteral).value, c.consequent])
                 );
 
-                const statements = [];
+                const statements: t.Statement[] = [];
                 for (let i = initialValue; ; i++) {
                     const state = states[i];
                     if (!casesMap.has(state)) {
@@ -68,7 +68,11 @@ export class ControlFlowRecoverer extends Transformation {
                     }
 
                     const blockStatements = casesMap.get(state) as t.Statement[];
-                    statements.push(...blockStatements.filter(s => !t.isContinueStatement(s)));
+                    for (const statement of blockStatements) {
+                        if (!t.isContinueStatement(statement)) {
+                            statements.push(t.cloneNode(statement, true));
+                        }
+                    }
                     if (
                         blockStatements.length > 0 &&
                         t.isReturnStatement(blockStatements[blockStatements.length - 1])

--- a/src/deobfuscator/transformations/controlFlow/deadBranchRemover.ts
+++ b/src/deobfuscator/transformations/controlFlow/deadBranchRemover.ts
@@ -22,14 +22,16 @@ export class DeadBranchRemover extends Transformation {
                         const statements = t.isBlockStatement(path.node.consequent)
                             ? path.node.consequent.body
                             : [path.node.consequent];
-                        path.replaceWithMultiple(statements);
+                        path.replaceWithMultiple(statements.map(s => t.cloneNode(s, true)));
                         self.setChanged();
                     } else {
                         if (path.node.alternate) {
                             if (t.isBlockStatement(path.node.alternate)) {
-                                path.replaceWithMultiple(path.node.alternate.body);
+                                path.replaceWithMultiple(
+                                    path.node.alternate.body.map(s => t.cloneNode(s, true))
+                                );
                             } else {
-                                path.replaceWith(path.node.alternate);
+                                path.replaceWith(t.cloneNode(path.node.alternate, true));
                             }
                         } else {
                             path.remove();

--- a/src/deobfuscator/transformations/controlFlow/sequenceSplitter.ts
+++ b/src/deobfuscator/transformations/controlFlow/sequenceSplitter.ts
@@ -88,7 +88,7 @@ export class SequenceSplitter extends Transformation {
             VariableDeclaration(path) {
                 if (path.node.declarations.length > 1) {
                     const replacements = path.node.declarations.map(d =>
-                        t.variableDeclaration(path.node.kind, [d])
+                        t.variableDeclaration(path.node.kind, [t.cloneNode(d, true)])
                     );
 
                     if (


### PR DESCRIPTION
## Summary
- clone statements before reinserting them in control-flow transforms

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68565970b2cc8322a6efdc2d83e0d912