### PR TITLE
Use cloneNode in copyExpression

### DIFF
--- a/src/deobfuscator/helpers/misc.ts
+++ b/src/deobfuscator/helpers/misc.ts
@@ -1,6 +1,4 @@
-import generate from '@babel/generator';
 import * as t from '@babel/types';
-import {parseExpression} from '@babel/parser';
 
 /**
  * Copies an expression.
@@ -8,7 +6,7 @@ import {parseExpression} from '@babel/parser';
  * @returns The copy.
  */
 export const copyExpression = (expression: t.Expression): t.Expression => {
-    return parseExpression(generate(expression).code);
+    return t.cloneNode(expression, /* deep */ true);
 };
 
 /**


### PR DESCRIPTION
## Summary
- replace code generation approach with `t.cloneNode` for copying expressions
- remove unused imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68566c8090388322803d8a07bab66f07