### PR TITLE
Compute NodePath depth via ancestry

### DIFF
--- a/src/deobfuscator/transformations/objects/objectSimplifier.ts
+++ b/src/deobfuscator/transformations/objects/objectSimplifier.ts
@@ -34,11 +34,11 @@ export class ObjectSimplifier extends Transformation {
     public execute(log: LogFunction): boolean {
         const self = this;
         const usages: [NodePath, ProxyObject][] = [];
-        let depth = 0;
 
         traverse(this.ast, {
             enter(path) {
-                setProperty(path, 'depth', depth++);
+                const depth = path.getAncestry().length;
+                setProperty(path, 'depth', depth);
                 const variable = findConstantVariable<ProxyObjectExpression>(path, isProxyObjectExpression);
                 if (!variable) {
                     return;

--- a/src/deobfuscator/transformations/proxyFunctions/proxyFunctionInliner.ts
+++ b/src/deobfuscator/transformations/proxyFunctions/proxyFunctionInliner.ts
@@ -17,11 +17,11 @@ export class ProxyFunctionInliner extends Transformation {
      */
     public execute(log: LogFunction): boolean {
         const usages: [NodePath, ProxyFunctionVariable][] = [];
-        let depth = 0;
 
         traverse(this.ast, {
             enter(path) {
-                setProperty(path, 'depth', depth++);
+                const depth = path.getAncestry().length;
+                setProperty(path, 'depth', depth);
                 const variable = findConstantVariable<ProxyFunctionExpression>(path, isProxyFunctionExpression, true);
                 if (!variable) {
                     return;


### PR DESCRIPTION
## Summary
- calculate traversal depth using `path.getAncestry().length`
- remove manual depth counters for proxy function inlining and object simplification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68566c95e3b0832293376710c3b99250