### PR TITLE
Fix missing path.skip calls

### DIFF
--- a/src/deobfuscator/transformations/controlFlow/controlFlowRecoverer.ts
+++ b/src/deobfuscator/transformations/controlFlow/controlFlowRecoverer.ts
@@ -81,8 +81,10 @@ export class ControlFlowRecoverer extends Transformation {
                     }
                 }
 
+                path.skip();
                 path.remove();
                 nextPath.replaceWithMultiple(statements);
+                nextPath.skip();
                 self.setChanged();
             }
         });

--- a/src/deobfuscator/transformations/controlFlow/deadBranchRemover.ts
+++ b/src/deobfuscator/transformations/controlFlow/deadBranchRemover.ts
@@ -23,6 +23,7 @@ export class DeadBranchRemover extends Transformation {
                             ? path.node.consequent.body
                             : [path.node.consequent];
                         path.replaceWithMultiple(statements.map(s => t.cloneNode(s, true)));
+                        path.skip();
                         self.setChanged();
                     } else {
                         if (path.node.alternate) {
@@ -36,6 +37,7 @@ export class DeadBranchRemover extends Transformation {
                         } else {
                             path.remove();
                         }
+                        path.skip();
                         self.setChanged();
                     }
                 }
@@ -45,6 +47,7 @@ export class DeadBranchRemover extends Transformation {
                 if (self.isSemiLiteral(path.node.test)) {
                     const replacement = self.isTruthy(path.node.test) ? path.node.consequent : path.node.alternate;
                     path.replaceWith(replacement);
+                    path.skip();
                     self.setChanged();
                 }
                 // simplify expressions in form (a ? true : false)
@@ -64,6 +67,7 @@ export class DeadBranchRemover extends Transformation {
                     }
 
                     path.replaceWith(replacement);
+                    path.skip();
                     self.setChanged();
                 }
             }

--- a/src/deobfuscator/transformations/controlFlow/sequenceSplitter.ts
+++ b/src/deobfuscator/transformations/controlFlow/sequenceSplitter.ts
@@ -102,6 +102,7 @@ export class SequenceSplitter extends Transformation {
                     } else {
                         path.replaceWithMultiple(replacements);
                     }
+                    path.skip();
                     self.setChanged();
                 }
             },
@@ -109,6 +110,7 @@ export class SequenceSplitter extends Transformation {
                 const expressions = path.node.expressions;
                 if (expressions.length == 1) {
                     path.replaceWith(expressions[0]);
+                    path.skip();
                     self.setChanged();
                     return;
                 }
@@ -140,20 +142,22 @@ export class SequenceSplitter extends Transformation {
                     const firstExpressions = expressions.splice(0, expressions.length - 2);
 
                     if (firstExpressions.length > 0) {
-                        const expressionStatements = firstExpressions.map(e =>
-                            t.expressionStatement(e)
-                        );
-                        outerPath.insertBefore(expressionStatements);
-                        self.setChanged();
-                    }
-                } else {
-                    const lastExpression = expressions.splice(expressions.length - 1, 1)[0];
-                    const expressionStatements = expressions.map(e => t.expressionStatement(e));
+                    const expressionStatements = firstExpressions.map(e =>
+                        t.expressionStatement(e)
+                    );
                     outerPath.insertBefore(expressionStatements);
-                    path.replaceWith(lastExpression);
+                    path.skip();
                     self.setChanged();
                 }
+            } else {
+                const lastExpression = expressions.splice(expressions.length - 1, 1)[0];
+                const expressionStatements = expressions.map(e => t.expressionStatement(e));
+                outerPath.insertBefore(expressionStatements);
+                path.replaceWith(lastExpression);
+                path.skip();
+                self.setChanged();
             }
+        }
         });
 
         return this.hasChanged();

--- a/src/deobfuscator/transformations/expressions/expressionSimplifier.ts
+++ b/src/deobfuscator/transformations/expressions/expressionSimplifier.ts
@@ -52,6 +52,7 @@ export class ExpressionSimplifier extends Transformation {
                     : self.simplifyBinaryExpression(path.node as t.BinaryExpression);
                 if (replacement) {
                     path.replaceWith(replacement);
+                    path.skip();
                     self.setChanged();
                 }
             }


### PR DESCRIPTION
## Summary
- avoid re-traversal after expression simplification
- skip over replaced nodes in SequenceSplitter
- prevent double visiting in ControlFlowRecoverer
- add skipping to DeadBranchRemover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68566e9a8664832285bb8446e5f2e0ab