### PR TITLE
Limit proxy inliner cloning

### DIFF
--- a/src/deobfuscator/helpers/misc.ts
+++ b/src/deobfuscator/helpers/misc.ts
@@ -1,4 +1,5 @@
 import * as t from '@babel/types';
+import traverse from '@babel/traverse';
 
 /**
  * Copies an expression.
@@ -7,6 +8,22 @@ import * as t from '@babel/types';
  */
 export const copyExpression = (expression: t.Expression): t.Expression => {
     return t.cloneNode(expression, /* deep */ true);
+};
+
+/**
+ * Counts the number of nodes contained within a node.
+ * @param node The node.
+ * @returns The number of nodes.
+ */
+export const countNodes = (node: t.Node): number => {
+    let count = 0;
+    traverse(node, {
+        enter() {
+            count++;
+        },
+        noScope: true
+    });
+    return count;
 };
 
 /**

--- a/src/deobfuscator/transformations/proxyFunctions/proxyFunctionInliner.ts
+++ b/src/deobfuscator/transformations/proxyFunctions/proxyFunctionInliner.ts
@@ -1,14 +1,17 @@
 import { LogFunction, Transformation, TransformationProperties } from '../transformation';
 import traverse, { NodePath } from '@babel/traverse';
+import * as t from '@babel/types';
 import { findConstantVariable } from '../../helpers/variable';
 import { ProxyFunctionExpression, ProxyFunctionVariable, isProxyFunctionExpression } from './proxyFunction';
-import { getProperty, setProperty } from '../../helpers/misc';
+import { getProperty, setProperty, countNodes } from '../../helpers/misc';
 
 export class ProxyFunctionInliner extends Transformation {
     public static readonly properties: TransformationProperties = {
         key: 'proxyFunctionInlining',
         rebuildScopeTree: true
     };
+
+    private static readonly MAX_CLONED_NODES = 10000;
 
     /**
      * Executes the transformation.
@@ -17,6 +20,8 @@ export class ProxyFunctionInliner extends Transformation {
      */
     public execute(log: LogFunction): boolean {
         const usages: [NodePath, ProxyFunctionVariable][] = [];
+        let skipped = 0;
+        let replacements = 0;
 
         traverse(this.ast, {
             enter(path) {
@@ -28,9 +33,28 @@ export class ProxyFunctionInliner extends Transformation {
                 }
 
                 const proxyFunction = new ProxyFunctionVariable(variable);
-                usages.push(
-                    ...proxyFunction.getCalls().map(p => [p, proxyFunction] as [NodePath, ProxyFunctionVariable])
+                const calls = proxyFunction.getCalls();
+
+                const expression = t.isExpression(variable.expression.body)
+                    ? variable.expression.body
+                    : variable.expression.body.body[0].argument || t.identifier('undefined');
+                const size = countNodes(expression);
+
+                log(
+                    `Found proxy function ${variable.name} with size ${size} nodes and ${calls.length} call${
+                        calls.length == 1 ? '' : 's'
+                    }`
                 );
+
+                if (size * calls.length > ProxyFunctionInliner.MAX_CLONED_NODES) {
+                    log(
+                        `Skipping ${variable.name} as cloning would create ${size * calls.length} nodes`
+                    );
+                    skipped += calls.length;
+                    return;
+                }
+
+                usages.push(...calls.map(p => [p, proxyFunction] as [NodePath, ProxyFunctionVariable]));
             }
         });
 
@@ -39,8 +63,15 @@ export class ProxyFunctionInliner extends Transformation {
         for (const [path, proxyFunction] of usages) {
             if (proxyFunction.replaceCall(path)) {
                 this.setChanged();
+                replacements++;
             }
         }
+
+        log(
+            `Replaced ${replacements} call${replacements == 1 ? '' : 's'}${
+                skipped ? `, skipped ${skipped}` : ''
+            }`
+        );
 
         return this.hasChanged();
     }


### PR DESCRIPTION
## Summary
- add a `countNodes` helper
- skip `ProxyFunctionInliner` when the return expression would clone more than 10k nodes
- add debug logging to understand why proxy inlining is inefficient

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685687233e4c83228c86cdb5ab7b8ee5